### PR TITLE
➕ Depend on `nlohmann_json` directly

### DIFF
--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -52,6 +52,16 @@ FetchContent_Declare(
   FIND_PACKAGE_ARGS ${MQT_CORE_MINIMUM_VERSION})
 list(APPEND FETCH_PACKAGES mqt-core)
 
+set(JSON_VERSION
+    3.12.0
+    CACHE STRING "nlohmann_json version")
+set(JSON_URL https://github.com/nlohmann/json/releases/download/v${JSON_VERSION}/json.tar.xz)
+set(JSON_SystemInclude
+    ON
+    CACHE INTERNAL "Treat the library headers like system headers")
+FetchContent_Declare(nlohmann_json URL ${JSON_URL} FIND_PACKAGE_ARGS ${JSON_VERSION})
+list(APPEND FETCH_PACKAGES nlohmann_json)
+
 if(BUILD_MQT_QUSAT_TESTS)
   set(gtest_force_shared_crt
       ON


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

MQT QuSAT exposes `nlohmann::json` in its own public API (`Statistics` and `SatEncoder`) and already links `nlohmann_json::nlohmann_json` publicly, but it never declared the dependency. The target only resolved because MQT Core fetches `nlohmann_json` and makes it available in the same build tree.

MQT Core is removing `nlohmann_json` from its public package contract (munich-quantum-toolkit/core#2099). This declares `nlohmann_json` in `cmake/ExternalDependencies.cmake` so that QuSAT fetches or finds it itself. Purely a build-system change; no public API is affected.

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/qusat/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
