### PR TITLE
♻️ Localize SAT encoder dependency graph

### DIFF
--- a/include/SatEncoder.hpp
+++ b/include/SatEncoder.hpp
@@ -11,7 +11,6 @@
 #pragma once
 
 #include "Statistics.hpp"
-#include "circuit_optimizer/CircuitOptimizer.hpp"
 #include "ir/QuantumComputation.hpp"
 
 #include <cstddef>
@@ -77,6 +76,8 @@ public:
   [[nodiscard]] const Statistics& getStats() const;
 
 private:
+  using DAG = std::vector<std::vector<const qc::Operation*>>;
+
   struct QState {
     unsigned long                  n;
     std::vector<std::vector<bool>> x;
@@ -107,9 +108,10 @@ private:
 
   static bool isClifford(const qc::QuantumComputation& qc);
 
+  static DAG constructDAG(const qc::QuantumComputation& circuit);
+
   CircuitRepresentation
-  preprocessCircuit(const qc::CircuitOptimizer::DAG& dag,
-                    const std::vector<std::string>&  inputs);
+  preprocessCircuit(const DAG& dag, const std::vector<std::string>& inputs);
 
   void constructSatInstance(
       const CircuitRepresentation& circuitRepresentation,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,7 +285,7 @@ test-skip = [
 ]
 
 # The mqt-core shared libraries are provided by the mqt-core Python package.
-# They should not be vendorized into the mqt-qcec wheel. This requires
+# They should not be vendorized into the mqt-qusat wheel. This requires
 # excluding the shared libraries from the repair process.
 
 [tool.cibuildwheel.linux]
@@ -295,8 +295,7 @@ repair-wheel-command = [
     "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/python/cp311-cp311/lib/python3.11/site-packages/z3/lib",
     """auditwheel repair -w {dest_dir} {wheel} \
   --exclude libmqt-core-ir.so.3.9 \
-  --exclude libmqt-core-qasm.so.3.9 \
-  --exclude libmqt-core-circuit-optimizer.so.3.9""",
+  --exclude libmqt-core-qasm.so.3.9""",
 ]
 
 [tool.cibuildwheel.macos]
@@ -306,8 +305,7 @@ repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest
 [tool.cibuildwheel.windows]
 repair-wheel-command = """delvewheel repair -w {dest_dir} {wheel} --namespace-pkg mqt \
 --exclude mqt-core-ir.dll \
---exclude mqt-core-qasm.dll \
---exclude mqt-core-circuit-optimizer.dll"""
+--exclude mqt-core-qasm.dll"""
 
 [tool.uv]
 required-version = ">=0.6.9"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,7 @@ target_include_directories(${MQT_QUSAT_TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}
 # link to the MQT::Core libraries
 target_link_libraries(
   ${MQT_QUSAT_TARGET_NAME}
-  PUBLIC MQT::CoreIR MQT::CoreCircuitOptimizer nlohmann_json::nlohmann_json
+  PUBLIC MQT::CoreIR nlohmann_json::nlohmann_json
   PRIVATE MQT::ProjectOptions MQT::ProjectWarnings)
 
 # add z3 SMT solver

--- a/src/SatEncoder.cpp
+++ b/src/SatEncoder.cpp
@@ -29,10 +29,10 @@ bool SatEncoder::testEqual(qc::QuantumComputation&         circuit,
     std::cerr << "Both circuits must be non-empty" << std::endl;
     return false;
   }
-  stats.nrOfDiffInputStates = inputs.size();
-  stats.nrOfQubits          = circuit.getNqubits();
-  const auto dagOne         = qc::CircuitOptimizer::constructDAG(circuit);
-  const auto dagTwo         = qc::CircuitOptimizer::constructDAG(circuitTwo);
+  stats.nrOfDiffInputStates              = inputs.size();
+  stats.nrOfQubits                       = circuit.getNqubits();
+  const auto                  dagOne     = constructDAG(circuit);
+  const auto                  dagTwo     = constructDAG(circuitTwo);
   const CircuitRepresentation circOneRep = preprocessCircuit(dagOne, inputs);
   const CircuitRepresentation circTwoRep = preprocessCircuit(dagTwo, inputs);
   z3::context                 ctx{};
@@ -62,7 +62,7 @@ bool SatEncoder::checkSatisfiability(qc::QuantumComputation&         circuitOne,
   }
   stats.nrOfDiffInputStates = inputs.size();
   stats.nrOfQubits          = circuitOne.getNqubits();
-  const auto  dag           = qc::CircuitOptimizer::constructDAG(circuitOne);
+  const auto  dag           = constructDAG(circuitOne);
   const auto  circRep       = preprocessCircuit(dag, inputs);
   z3::context ctx{};
   z3::solver  solver(ctx);
@@ -73,7 +73,7 @@ bool SatEncoder::checkSatisfiability(qc::QuantumComputation&         circuitOne,
 }
 
 std::string SatEncoder::generateDIMACS(qc::QuantumComputation& qc) {
-  const auto                  dag  = qc::CircuitOptimizer::constructDAG(qc);
+  const auto                  dag  = constructDAG(qc);
   const CircuitRepresentation circ = preprocessCircuit(dag, {});
 
   z3::context ctx{};
@@ -120,9 +120,20 @@ bool SatEncoder::isSatisfiable(z3::solver& solver) {
   return stats.satisfiable;
 }
 
+SatEncoder::DAG
+SatEncoder::constructDAG(const qc::QuantumComputation& circuit) {
+  auto dag = DAG(circuit.getHighestPhysicalQubitIndex() + 1U);
+  for (const auto& operation : circuit) {
+    for (const auto qubit : operation->getUsedQubits()) {
+      dag.at(qubit).push_back(operation.get());
+    }
+  }
+  return dag;
+}
+
 SatEncoder::CircuitRepresentation
-SatEncoder::preprocessCircuit(const qc::CircuitOptimizer::DAG& dag,
-                              const std::vector<std::string>&  inputs) {
+SatEncoder::preprocessCircuit(const DAG&                      dag,
+                              const std::vector<std::string>& inputs) {
   const auto            before     = std::chrono::high_resolution_clock::now();
   const std::size_t     inputSize  = dag.size();
   std::size_t           nrOfLevels = 0;
@@ -178,8 +189,8 @@ SatEncoder::preprocessCircuit(const qc::CircuitOptimizer::DAG& dag,
         if (!dag.at(qubitCnt).empty() &&
             dag.at(qubitCnt).at(levelCnt) != nullptr) {
           stats.nrOfGates++;
-          const auto gate = dag.at(qubitCnt).at(levelCnt)->get();
-          const auto target =
+          const auto* gate = dag.at(qubitCnt).at(levelCnt);
+          const auto  target =
               gate->getTargets().at(0U); // we assume we only have 1 target
 
           for (auto& currState : states) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,4 +7,5 @@
 # Licensed under the MIT License
 
 package_add_test(${MQT_QUSAT_TARGET_NAME}_test ${MQT_QUSAT_TARGET_NAME} test_satencoder.cpp)
-target_link_libraries(${MQT_QUSAT_TARGET_NAME}_test PRIVATE MQT::CoreAlgorithms)
+target_link_libraries(${MQT_QUSAT_TARGET_NAME}_test PRIVATE MQT::CoreAlgorithms
+                                                            MQT::CoreCircuitOptimizer)

--- a/test/test_satencoder.cpp
+++ b/test/test_satencoder.cpp
@@ -35,16 +35,16 @@ TEST_F(SatEncoderTest, CheckEqualWhenEqualRandomCircuits) {
   EXPECT_EQ(result, true);
 }
 
-TEST_F(SatEncoderTest, CheckEqualWithMultiQubitGate) {
-  qc::QuantumComputation circOne(3);
+TEST_F(SatEncoderTest, CheckNotEqualWithMultiQubitGate) {
+  qc::QuantumComputation circOne(2);
   circOne.h(0);
-  circOne.s(1);
-  circOne.cx(0, 2);
-  circOne.h(2);
-  auto circTwo = circOne;
+  circOne.cx(0, 1);
+
+  qc::QuantumComputation circTwo(2);
+  circTwo.h(0);
 
   SatEncoder encoder;
-  EXPECT_TRUE(encoder.testEqual(circOne, circTwo));
+  EXPECT_FALSE(encoder.testEqual(circOne, circTwo));
   EXPECT_EQ(encoder.getStats().circuitDepth, 2);
 }
 

--- a/test/test_satencoder.cpp
+++ b/test/test_satencoder.cpp
@@ -35,6 +35,19 @@ TEST_F(SatEncoderTest, CheckEqualWhenEqualRandomCircuits) {
   EXPECT_EQ(result, true);
 }
 
+TEST_F(SatEncoderTest, CheckEqualWithMultiQubitGate) {
+  qc::QuantumComputation circOne(3);
+  circOne.h(0);
+  circOne.s(1);
+  circOne.cx(0, 2);
+  circOne.h(2);
+  auto circTwo = circOne;
+
+  SatEncoder encoder;
+  EXPECT_TRUE(encoder.testEqual(circOne, circTwo));
+  EXPECT_EQ(encoder.getStats().circuitDepth, 2);
+}
+
 TEST_F(SatEncoderTest, CheckErrorWhenEmpty) {
   std::random_device rd;
   std::mt19937       gen(rd());


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Localize the operation DAG used by `SatEncoder` so MQT QuSAT no longer depends on the `MQT::CoreCircuitOptimizer` production target.

- Add a private, const-correct DAG representation and builder in `SatEncoder`.
- Keep `MQT::CoreCircuitOptimizer` test-only for the existing circuit-flattening helpers.
- Remove the optimizer shared library from the Linux and Windows wheel exclusions.
- Cover multi-qubit DAG layering with a regression test.

This is the QuSAT consumer migration for munich-quantum-toolkit/core#2088 and should merge before the corresponding Core API removal. It changes no public QuSAT API and adds no dependencies.

AI assistance was used to trace the production dependency, implement and review the migration, run validation, and prepare this description.

## Validation

- `cmake --build --preset release`
- `ctest --preset release` (11/11 tests passed)
- `uvx nox -s lint`
- `git diff --check`

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] Documentation changes are not needed because this is an internal dependency migration with no public API change.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks. Local validation passes; CI is pending.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for this scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/qusat/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
