### PR TITLE
♻️ Migrate flattening tests to Core v4

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,5 +7,4 @@
 # Licensed under the MIT License
 
 package_add_test(${MQT_QUSAT_TARGET_NAME}_test ${MQT_QUSAT_TARGET_NAME} test_satencoder.cpp)
-target_link_libraries(${MQT_QUSAT_TARGET_NAME}_test PRIVATE MQT::CoreAlgorithms
-                                                            MQT::CoreCircuitOptimizer)
+target_link_libraries(${MQT_QUSAT_TARGET_NAME}_test PRIVATE MQT::CoreAlgorithms)

--- a/test/test_satencoder.cpp
+++ b/test/test_satencoder.cpp
@@ -10,7 +10,6 @@
 
 #include "SatEncoder.hpp"
 #include "algorithms/RandomCliffordCircuit.hpp"
-#include "circuit_optimizer/CircuitOptimizer.hpp"
 
 #include <ctime>
 #ifdef _MSC_VER
@@ -20,6 +19,7 @@
 #include <fstream>
 #include <gtest/gtest.h>
 #include <locale>
+#include <random>
 
 class SatEncoderTest : public testing::TestWithParam<std::string> {};
 
@@ -27,7 +27,7 @@ TEST_F(SatEncoderTest, CheckEqualWhenEqualRandomCircuits) {
   std::random_device rd;
   std::mt19937       gen(rd());
   auto               circOne = qc::createRandomCliffordCircuit(2, 1, gen());
-  qc::CircuitOptimizer::flattenOperations(circOne);
+  circOne.flattenOperations();
   auto circTwo = circOne;
 
   SatEncoder satEncoder;
@@ -67,7 +67,7 @@ TEST_F(SatEncoderTest, CheckEqualWhenNotEqualRandomCircuits) {
     circOne = qc::createRandomCliffordCircuit(2, 1, gen());
   }
 
-  qc::CircuitOptimizer::flattenOperations(circOne);
+  circOne.flattenOperations();
   auto circTwo = circOne;
 
   circTwo.erase(circTwo.begin());
@@ -81,7 +81,7 @@ TEST_F(SatEncoderTest, CheckEqualWhenEqualRandomCircuitsWithInputs) {
   std::random_device rd;
   std::mt19937       gen(rd());
   auto               circOne = qc::createRandomCliffordCircuit(50, 10, gen());
-  qc::CircuitOptimizer::flattenOperations(circOne);
+  circOne.flattenOperations();
   auto circTwo = circOne;
 
   SatEncoder               satEncoder;
@@ -100,7 +100,7 @@ TEST_F(SatEncoderTest, CheckSATConstructionWithSmallCircuit) {
   std::random_device rd;
   std::mt19937       gen(rd());
   auto               circOne = qc::createRandomCliffordCircuit(1, 1, gen());
-  qc::CircuitOptimizer::flattenOperations(circOne);
+  circOne.flattenOperations();
 
   SatEncoder satEncoder;
 
@@ -114,7 +114,7 @@ TEST_F(SatEncoderTest, CheckDIMACSConstructionWithSmallCircuit) {
   std::random_device rd;
   std::mt19937       gen(rd());
   auto               circOne = qc::createRandomCliffordCircuit(6, 1, gen());
-  qc::CircuitOptimizer::flattenOperations(circOne);
+  circOne.flattenOperations();
 
   SatEncoder satEncoder;
 
@@ -174,7 +174,7 @@ TEST_F(SatEncoderBenchmarking,
           SatEncoder satEncoder;
           auto       circOne = qc::createRandomCliffordCircuit(
               static_cast<qc::Qubit>(nrOfQubits), depth, rd());
-          qc::CircuitOptimizer::flattenOperations(circOne);
+          circOne.flattenOperations();
           if (nrOfQubits != 1U || j != 0U) {
             outfile << ", ";
           }
@@ -221,7 +221,7 @@ TEST_F(SatEncoderBenchmarking,
           SatEncoder satEncoder;
           auto       circOne = qc::createRandomCliffordCircuit(
               static_cast<qc::Qubit>(nrOfQubits), depth, rd());
-          qc::CircuitOptimizer::flattenOperations(circOne);
+          circOne.flattenOperations();
           if (depth != 1U || j != 0U) {
             outfile << ", ";
           }
@@ -268,7 +268,7 @@ TEST_F(SatEncoderBenchmarking,
           SatEncoder satEncoder;
           auto       circOne = qc::createRandomCliffordCircuit(
               static_cast<qc::Qubit>(nrOfQubits), depth, rd());
-          qc::CircuitOptimizer::flattenOperations(circOne);
+          circOne.flattenOperations();
           if (depth != 1U || j != 0U) {
             outfile << ", ";
           }
@@ -325,7 +325,7 @@ TEST_F(SatEncoderBenchmarking,
 
       auto circOne = qc::createRandomCliffordCircuit(
           static_cast<qc::Qubit>(qubitCnt), depth, gen());
-      qc::CircuitOptimizer::flattenOperations(circOne);
+      circOne.flattenOperations();
       auto circTwo = circOne;
       if (qubitCnt != 4) {
         outfile << ", ";
@@ -348,7 +348,7 @@ TEST_F(SatEncoderBenchmarking,
         SatEncoder satEncoder1;
         auto       circThree = qc::createRandomCliffordCircuit(
             static_cast<qc::Qubit>(qubitCnt), depth, gen());
-        qc::CircuitOptimizer::flattenOperations(circThree);
+        circThree.flattenOperations();
         auto                                       circFour = circThree;
         std::uniform_int_distribution<std::size_t> distr2(
             0U, circFour.size()); // random error location in circuit


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Prepare QuSAT's tests for the removal of `qc::CircuitOptimizer` in [MQT Core #2262](https://github.com/munich-quantum-toolkit/core/pull/2262):

- replace the ten static flattening calls with `QuantumComputation::flattenOperations()`;
- remove the obsolete optimizer header and CMake target; and
- include `<random>` directly now that it is no longer supplied transitively.

This intentionally leaves the MQT Core version requirement and `uv.lock` unchanged. The PR must remain a draft until Core v4 is released, at which point the dependency pin can be updated and the PR revalidated.

## Dependencies and merge order

This PR depends on Core #2262 and should merge only after the Core v4 release. Full validation against the Core v4 branch used a temporary out-of-tree `MQT::CoreAlgorithms` compatibility shim for that separate Core v4 migration; no shim or unrelated migration is part of this diff.

## Companion migration drafts

- Core: [munich-quantum-toolkit/core#2262](https://github.com/munich-quantum-toolkit/core/pull/2262)
- QCEC: [munich-quantum-toolkit/qcec#1042](https://github.com/munich-quantum-toolkit/qcec/pull/1042)
- QMAP: [munich-quantum-toolkit/qmap#1125](https://github.com/munich-quantum-toolkit/qmap/pull/1125)
- QuSAT: [munich-quantum-toolkit/qusat#514](https://github.com/munich-quantum-toolkit/qusat/pull/514)
- DDSIM: [munich-quantum-toolkit/ddsim#977](https://github.com/munich-quantum-toolkit/ddsim/pull/977)
- Debugger: [munich-quantum-toolkit/debugger#438](https://github.com/munich-quantum-toolkit/debugger/pull/438)

## Validation

- warning-clean build with `WARNINGS_AS_ERRORS=ON`
- 7/7 affected SAT encoder tests
- 11/11 full C++ tests
- complete 388-target build
- full `uvx nox -s lint`
- `git diff --check`

## AI assistance

Codex materially assisted with implementation, validation, review, and this pull request description. A human must review and understand the changes before marking this pull request ready.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes. (Not applicable: test-only dependency migration.)
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks. Local Core v4 validation passes; CI requires the future Core v4 pin.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/qusat/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
